### PR TITLE
Fix dns-sd cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Your system will be returned to its original state (i.e., as if AirPrint Bridge 
 - **Permission Issues**: Use `sudo` for installation or uninstallation.
 - **Firewall Issues**: Make sure printer sharing and Bonjour services aren’t blocked in your macOS firewall.
 - **No Output in Log**: If you enabled logging but see no file, ensure the script has permission to create/write the file.
+- **Phantom Printer Remains**: Toggle macOS **Printer Sharing** off and back on if a printer still appears after uninstalling.
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary
- bump script version to 1.3.2
- kill leftover `dns-sd` processes during uninstall
- document toggling Printer Sharing if phantom printers remain

## Testing
- `bash -n airprint_bridge.sh`
- `shellcheck airprint_bridge.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dac7e1bf8832f8e8f8c92c831ec75