### PR TITLE
Fix shared printer detection on macOS Sequoia+

### DIFF
--- a/airprint_bridge.sh
+++ b/airprint_bridge.sh
@@ -178,7 +178,8 @@ browse_printers() {
 
     shared_printers=()
     while IFS= read -r printer; do
-        if lpoptions -p "$printer" | grep -q 'printer-is-shared=true'; then
+        if lpoptions -p "$printer" | grep -q 'printer-is-shared=true' || \
+           grep -A1 "<.*Printer $printer>" /etc/cups/printers.conf 2>/dev/null | grep -q 'Shared Yes'; then
             shared_printers+=("$printer")
         fi
     done <<< "$all_printers"


### PR DESCRIPTION
## Summary

- On macOS Sequoia (and likely Sonoma+), `lpoptions` no longer reports `printer-is-shared=true` even when the printer is shared via `/etc/cups/printers.conf`
- This causes `browse_printers()` to find zero shared printers, making the script fail with "No shared printers found"
- Adds a fallback that checks `/etc/cups/printers.conf` directly for `Shared Yes`
- The original `lpoptions` check is preserved as the first condition for backwards compatibility

## Test plan

- [x] Tested on macOS Sequoia 15.3 with HP LaserJet 3200 shared via CUPS
- [x] Confirmed `lpoptions` does not report `printer-is-shared=true` on this macOS version
- [x] Confirmed the fallback correctly detects `Shared Yes` in `/etc/cups/printers.conf`
- [x] Verified `sudo bash airprint_bridge.sh -t` successfully finds and registers the printer
- [x] Verified `sudo bash airprint_bridge.sh -i` installs and persists across reboot
- [x] Verified iPhone discovers and prints to the bridged printer