### PR TITLE
Detect color support from Brother BRMonoColor option

### DIFF
--- a/airprint_bridge.sh
+++ b/airprint_bridge.sh
@@ -240,14 +240,14 @@ generate_urf() {
     while IFS= read -r line; do
         case "$line" in
             # Color Mode Options
-            *"ColorModel"*)
+            *"ColorModel"*|*"BRMonoColor"*)
                 IFS=' ' read -r -a color_modes <<< "$(echo "$line" | awk -F':' '{print $2}' | sed 's/^ *//')"
                 for color_mode in "${color_modes[@]}"; do
                     case "$color_mode" in
-                        *Gray*|*Black*)
+                        *Gray*|*Black*|*Mono*)
                             add_urf_code "W8"
                             ;;
-                        *RGB*|*Color*)
+                        *RGB*|*Color*|*FullColor*|*Auto*)
                             add_urf_code "SRGB24"
                             HAS_COLOR=1
                             ;;


### PR DESCRIPTION
## Summary

This fixes color detection for Brother CUPS drivers that expose color capability through `BRMonoColor` instead of `ColorModel`.

For example, the Brother MFC-9560CDW macOS CUPS driver reports:

```text
BRMonoColor/Color / Mono: *Auto FullColor Mono
```

Before this change, AirPrint_Bridge did not detect this as color-capable and generated `Color=F`.

## Change

The color parser now also checks `BRMonoColor` lines and treats `FullColor` and `Auto` as color-capable values.

## Validation

Tested with:

```text
lpoptions -p Brother_MFC_9560CDW -l
Duplex/Two-Sided Printing: DuplexTumble DuplexNoTumble *None
BRMonoColor/Color / Mono: *Auto FullColor Mono
BRColorMatching/Color Mode: *Normal Vivid None
BRGray/Improve Gray Color: OFF *ON
```

After the change, AirPrint_Bridge generated the expected color-capable TXT records:

```text
URF=V1.4,MS_A4,MS_LETTER,MS_LEGAL,MS_EXECUTIVE,MS_A5,MS_A6,MS_B5,DM3,DM2,DM1,SRGB24,W8
Color=T
Duplex=T
```

For iOS to show the Color switch, the local CUPS queue also needed a clean `print-color-mode` configuration. On the test system, this was done with:

```bash
lpadmin -p Brother_MFC_9560CDW -R print-color-mode-default
lpadmin -p Brother_MFC_9560CDW -o print-color-mode=color
```

After that, the queue advertised clean IPP color attributes:

```text
color-supported (boolean) = true
print-color-mode-supported (1setOf keyword) = monochrome,color
print-color-mode-default (keyword) = color
```

The iOS AirPrint dialog then displayed the Color switch and color printing worked.

## Note

This PR does not force `print-color-mode` defaults globally. It only corrects color detection when Brother drivers expose color capability through `BRMonoColor`. The `lpadmin` commands above were local queue cleanup needed for the tested environment.